### PR TITLE
Changed ProductId constructor arguments from Int to Integer.

### DIFF
--- a/Web/Ebay.hs
+++ b/Web/Ebay.hs
@@ -164,7 +164,7 @@ instance ToJSON OutputSelector where
 instance FromJSON OutputSelector
 
 
-data ProductId = EAN Int | ISBN Int | UPC Int | ReferenceId String deriving Show
+data ProductId = EAN Integer | ISBN Integer | UPC Integer | ReferenceId String deriving Show
 
 productIdToParams :: ProductId -> (String, String)
 productIdToParams (EAN ean) = ("EAN", show ean)


### PR DESCRIPTION
This is due to the numbers being longer than the max size of Int that the Haskell spec guarantees.
